### PR TITLE
weekly builds and skip builds for .md changes

### DIFF
--- a/.github/workflows/build_on_pr.yml
+++ b/.github/workflows/build_on_pr.yml
@@ -1,0 +1,31 @@
+name: buildx on PR
+
+on:
+  pull_request:
+    branches: master
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  buildx:
+    runs-on: ubuntu-latest
+    steps:
+      # Get the repositery's code
+      - name: Checkout
+        uses: actions/checkout@v2
+      
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v2
+        with: # in production, fix the version of your dependencies
+          buildx-version: latest
+          skip-cache: false
+          qemu-version: latest
+      
+      # Build the images, without pushing
+      - name: Run Buildx
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64,linux/386,linux/arm/v7,linux/arm/v6 \
+            .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,10 +1,6 @@
 name: buildx
 
 on:
-  pull_request:
-    branches: master
-    paths-ignore:
-      - '**.md'
   push:
     branches: master
     paths-ignore:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,14 @@ name: buildx
 on:
   pull_request:
     branches: master
+    paths-ignore:
+      - '**.md'
   push:
     branches: master
-    tags:
+    paths-ignore:
+      - '**.md'
+  schedule:
+    - cron: "0 4 */8 * *" # almost weekly
 
 jobs:
   buildx:


### PR DESCRIPTION
Hi there, 

A PR with 2 nice-to-haves.

1. Schedule for aumatic weekly builds, important for potential security patches on raspotify, as it's a service. Though it has potential to brake thing, this way fixes on raspotify are guarenteed to be included in a week.

2. Don't trigger builds on `*.md` file changes. No need to waste resources.